### PR TITLE
fix: 修复标尺刻度文字不显示的 bug

### DIFF
--- a/src/canvas-ruler/index.vue
+++ b/src/canvas-ruler/index.vue
@@ -51,7 +51,8 @@ export default defineComponent({
         scale: props.scale!,
         width: props.width!,
         height: props.height!,
-        palette: props.palette!
+        palette: props.palette!,
+        ratio: props.ratio!
       }
 
       if (state.canvasContext) {

--- a/src/canvas-ruler/utils.ts
+++ b/src/canvas-ruler/utils.ts
@@ -15,11 +15,11 @@ export const drawCavaseRuler = (
   start: number,
   selectStart: number,
   selectLength: number,
-  options: { scale: number; width: number; height: number; palette: any },
+  options: { scale: number; width: number; height: number; ratio: number; palette: any },
   h?: boolean //横向为true,纵向缺省
 ) => {
-  const { scale, width, height, palette } = options
-  const { bgColor, fontColor, shadowColor, ratio, longfgColor, shortfgColor } =
+  const { scale, width, height, ratio, palette } = options
+  const { bgColor, fontColor, shadowColor, longfgColor, shortfgColor } =
     palette
 
   // 缩放ctx, 以简化计算


### PR DESCRIPTION
`/src/canvas-ruler/utils.ts` 中的 `drawCavaseRuler` 方法错误的从 `otpions.palette` 中读取 `ratio` 属性，但实际上并没有这个属性，此次修改主要是解决这个问题
另外，请在 `npm` 上发布 `1.x` 的新版，我现在开发的项目中用到了这个库，谢谢！